### PR TITLE
Fix invalid pattern for testing msbuild availability for wp7

### DIFF
--- a/wp7/bin/check_reqs.js
+++ b/wp7/bin/check_reqs.js
@@ -80,7 +80,7 @@ function SystemRequiermentsMet() {
     var cmd = 'msbuild -version'
     var fail_msg = 'The command `msbuild` failed. Make sure you have the latest Windows Phone SDKs installed, AND have the latest .NET framework added to your path (i.e C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319).'
     var output = check_command(cmd, fail_msg);
-    var msversion = output.match(/\.NET\sFramework\,\sversion\s4\.0/);
+    var msversion = output.match(/\.NET\sFramework\,\s[Vv]ersion\s4\.0/);
     if (!msversion) {
         Log('Please install the .NET Framwork v4.0.30319 (in the latest windows phone SDK\'s).', true);
         Log('Make sure the "msbuild" command in your path is pointing to  v4.0.30319 of msbuild as well (inside C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319).', true);


### PR DESCRIPTION
I have tested with a fresh installation of Windows Phone SDK 7 and I was not able to create wp7 project. The problem was with check_reqs.js which checks msbuild availability. It calls "msbuild -version" which has following output:
Microsoft (R) Build Engine Version 4.0.30319.1
[Microsoft .NET Framework, Version 4.0.30319.225]
Copyright (C) Microsoft Corporation 2007. All rights reserved.

4.0.30319.1

Current pattern does not match because of capital 'v' in 'Version'. Fix tries to match both 'Version' and 'version'.
