### PR TITLE
disable idle detection mode when debug by default

### DIFF
--- a/wp7/template/App.xaml.cs
+++ b/wp7/template/App.xaml.cs
@@ -75,8 +75,10 @@ namespace $safeprojectname$
         // This code will not execute when the application is reactivated
         private void Application_Launching(object sender, LaunchingEventArgs e)
         {
-            // Avoid screen locks while debugging.
-            PhoneApplicationService.Current.UserIdleDetectionMode = IdleDetectionMode.Disabled;
+            if (System.Diagnostics.Debugger.IsAttached) {
+                // Avoid screen locks while debugging.
+                PhoneApplicationService.Current.UserIdleDetectionMode = IdleDetectionMode.Disabled;
+            }
         }
 
         // Code to execute when the application is activated (brought to foreground)


### PR DESCRIPTION
Hi!

I propose to disable idle detection when debugger is attached. Without this, it is very painful to work with app. For most of platforms (iOS, Android - option on device, BB10) this behavior is already enabled by default.

Thank you!
