### PR TITLE
[CB-5219] weinre disconnects when history.replaceState is used

### DIFF
--- a/wp8/template/cordovalib/XHRHelper.cs
+++ b/wp8/template/cordovalib/XHRHelper.cs
@@ -118,7 +118,9 @@ namespace WPCordovaClassLib.CordovaLib
             changeReadyState: function(newState) {
                 this.readyState = newState;
                 if (this.onreadystatechange) {
-                    this.onreadystatechange();
+                    // mimic simple 'readystatechange' event which should be passed as per spec
+                    var evt = {type: 'readystatechange', target: this, timeStamp: new Date().getTime()};
+                    this.onreadystatechange(evt);
                 }
                 if (this.readyState == XHRShim.DONE){
                     this.onload && this.onload();


### PR DESCRIPTION
Cordova XHR shim does not pass event argument for xhr.onreadystatechange event handler so some apps can work incorrect; Weinre for examples crashes and then disconnects. 
Added simple object which mimics required 'readystatechange' event instance.
See for details https://issues.apache.org/jira/browse/CB-5219
