### PR TITLE
Fix for position fix not working.

### DIFF
--- a/wp8/template/MainPage.xaml
+++ b/wp8/template/MainPage.xaml
@@ -29,6 +29,7 @@
     Foreground="{StaticResource PhoneForegroundBrush}"
     Background="Black"
     SupportedOrientations="PortraitOrLandscape" Orientation="Portrait"
+    shell:SystemTray.ForegroundColor="Black" shell:SystemTray.Opacity="0"
     shell:SystemTray.IsVisible="True" d:DesignHeight="768" d:DesignWidth="480" 
     xmlns:my="clr-namespace:WPCordovaClassLib">
     <Grid x:Name="LayoutRoot" Background="Transparent" HorizontalAlignment="Stretch">


### PR DESCRIPTION
Elements that are css 'fixed' currently jiggle. This change makes the WP8 web
view full screen and hides it underneath the system tray. Developers will need to add padding to their page as they do in iOS7 in order to make their app appear 100% underneath the system tray.
