### PR TITLE
CB-6878 Launching a specific Windows Emulator using the run command fails when spaces are in the path

### DIFF
--- a/wp8/template/cordova/lib/deploy.js
+++ b/wp8/template/cordova/lib/deploy.js
@@ -230,8 +230,7 @@ function target(path) {
     if (!fso.FileExists(path + CORDOVA_DEPLOY_EXE)) {
         cordovaDeploy(path);
     }
-    wscript_shell.CurrentDirectory = path + CORDOVA_DEPLOY + '\\CordovaDeploy\\bin\\Debug';
-    var cmd = 'CordovaDeploy -devices';
+    var cmd = '"' + path + CORDOVA_DEPLOY_EXE + '" -devices';
     var out = wscript_shell.Exec(cmd);
     while(out.Status == 0) {
         WScript.Sleep(100);
@@ -251,7 +250,7 @@ function target(path) {
                 if (targets[target].match(check_id)) {
                     //TODO: this only gets single digit index, account for device index of 10+?
                     var index = targets[target].substr(0,1);
-                    exec_verbose(path + CORDOVA_DEPLOY_EXE + ' ' + path + ' -d:' + index);
+                    exec_verbose('"' + path + CORDOVA_DEPLOY_EXE + '" "' + path + '" -d:' + index);
                     return;
                 }
             }


### PR DESCRIPTION
When trying to run app on specific target using --target== key

```
cordova run wp8 --target=5E7661DF-D928-40ff-B747-A4B1957194F9
```

i get following error:

```
ERROR: command failed in deploy.js : d:\PROJECTS\Temp\test-spaces 2\platforms\wp8\cordova\lib\CordovaDeploy\CordovaDeploy\bin\Debug\CordovaDeploy.exe d:\PROJECTS\Temp\test-spaces 2\platforms\wp8 -d:1
Error: the file d:\PROJECTS\Temp\test-spaces 2\platforms\wp8\cordova\lib\CordovaDeploy\CordovaDeploy\bin\Debug\Properties\WMAppManifest.xml does not exist
```

Reason: command that start CordovaDeploy is not escaped in target() function.

Fix for [CB-6878](https://issues.apache.org/jira/browse/CB-6878)
