### PR TITLE
CB-6924 Fixed memory leak in WP page navigation

### DIFF
--- a/wp8/template/cordovalib/ConsoleHelper.cs
+++ b/wp8/template/cordovalib/ConsoleHelper.cs
@@ -71,6 +71,15 @@ namespace WPCordovaClassLib.CordovaLib
             }
         }
 
+        public void DetachHandler()
+        {
+            if (hasListener)
+            {
+                PhoneApplicationService.Current.Closing -= OnServiceClosing;
+                hasListener = false;
+            }
+        }
+
         public bool HandleCommand(string commandStr)
         {
             string output = commandStr.Substring("ConsoleLog/".Length);

--- a/wp8/template/cordovalib/CordovaView.xaml.cs
+++ b/wp8/template/cordovalib/CordovaView.xaml.cs
@@ -513,7 +513,17 @@ namespace WPCordovaClassLib
 
         private void CordovaBrowser_Unloaded(object sender, RoutedEventArgs e)
         {
+            IBrowserDecorator console;
+            if (browserDecorators.TryGetValue("ConsoleLog", out console))
+            {
+                ((ConsoleHelper)console).DetachHandler();
+            }
 
+            PhoneApplicationService service = PhoneApplicationService.Current;
+            service.Activated -= new EventHandler<Microsoft.Phone.Shell.ActivatedEventArgs>(AppActivated);
+            service.Launching -= new EventHandler<LaunchingEventArgs>(AppLaunching);
+            service.Deactivated -= new EventHandler<DeactivatedEventArgs>(AppDeactivated);
+            service.Closing -= new EventHandler<ClosingEventArgs>(AppClosing);
         }
 
         private void CordovaBrowser_NavigationFailed(object sender, System.Windows.Navigation.NavigationFailedEventArgs e)


### PR DESCRIPTION
Occurred when navigating back and forth from native to hybrid page.
