### PR TITLE
CB-6977 Support chip architecture as an option for run command for Windows and Windows Phone projects

### DIFF
--- a/wp8/template/cordova/lib/build.js
+++ b/wp8/template/cordova/lib/build.js
@@ -173,7 +173,10 @@ function build_xap(path, buildtype, buildarchs) {
     Log("\tMSBuildToolsPath: " + MSBuildToolsPath);
 
     for (var i = 0; i < buildarchs.length; i++) {
-        var buildarch = buildarchs[i];
+
+        var buildarch = buildarchs[i].toLowerCase();
+        // support for "any cpu" specified with or without space
+        buildarch = buildarch !== "anycpu" ? buildarch : "any cpu";
 
         Log("Building Cordova-WP8 Project:");
         Log("\tConfiguration : " + buildtype);


### PR DESCRIPTION
Implementation for [CB-6977](https://issues.apache.org/jira/browse/CB-6977)
- Adds support for `--archs` option to `run` command.
- Adds ability to CordovaDeploy to deploy specific .xap file.
