### PR TITLE
CB-7028 fixed memory leak in wp with plugins

### DIFF
--- a/wp8/template/cordovalib/Commands/BaseCommand.cs
+++ b/wp8/template/cordovalib/Commands/BaseCommand.cs
@@ -172,6 +172,16 @@ namespace WPCordovaClassLib.Cordova.Commands
             this.OnCommandResult = null;
         }
 
+        public void DetachHandlers()
+        {
+            this.OnCommandResult = null;
+            this.OnCustomScript = null;
+            foreach (string callbackId in new List<string>(ResultHandlers.Keys))
+            {
+                RemoveResultHandler(callbackId);
+            }
+        }
+
         public static string GetBaseURL()
         {
 #if CORDOVA_CLASSLIB

--- a/wp8/template/cordovalib/NativeExecution.cs
+++ b/wp8/template/cordovalib/NativeExecution.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using Microsoft.Devices;
 using Microsoft.Phone.Controls;
 using WPCordovaClassLib.Cordova.Commands;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace WPCordovaClassLib.Cordova
@@ -34,6 +35,11 @@ namespace WPCordovaClassLib.Cordova
         private readonly WebBrowser webBrowser;
 
         /// <summary>
+        /// List of commands with attached handlers
+        /// </summary>
+        private List<BaseCommand> commands;
+
+        /// <summary>
         /// Creates new instance of a NativeExecution class.
         /// </summary>
         /// <param name="browser">Reference to web part where application is hosted</param>
@@ -45,6 +51,22 @@ namespace WPCordovaClassLib.Cordova
             }
 
             this.webBrowser = browser;
+            this.commands = new List<BaseCommand>();
+            webBrowser.Unloaded += webBrowser_Unloaded;
+        }
+
+        /// <summary>
+        /// Detaches event handlers to prevent memory leak on page navigation
+        /// </summary>
+        void webBrowser_Unloaded(object sender, RoutedEventArgs e)
+        {
+            for (int i = commands.Count - 1; i >= 0; i--)
+            {
+                if (commands[i] != null)
+                {
+                    commands[i].DetachHandlers();
+                }
+            }
         }
 
         /// <summary>
@@ -120,6 +142,7 @@ namespace WPCordovaClassLib.Cordova
                     try
                     {
                         bc.InvokeMethodNamed(commandCallParams.CallbackId, commandCallParams.Action, commandCallParams.Args);
+                        commands.Add(bc);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
When navigating between a native and hybrid page in wp8, if the
network-information or device plugins are installed the hybrid page will
never get garbage collected. Fixed by removing event handlers for commands
when the web browser is unloaded.
