### PR TITLE
JsonHelper testing, and use of Newtonsoft.Json library to compile/decompile JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ Thumbs.db
 framework/Bin/*
 
 node_modules/
+
+testing/**/bin
+testing/**/Bin
+testing/**/obj
+testing/**/Obj
+testing/packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "template/cordovalib/JSON/lib/Newtonsoft.Json"]
+	path = template/cordovalib/JSON/lib/Newtonsoft.Json
+	url = https://github.com/JamesNK/Newtonsoft.Json.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "template/cordovalib/JSON/lib/Newtonsoft.Json"]
-	path = template/cordovalib/JSON/lib/Newtonsoft.Json
-	url = https://github.com/JamesNK/Newtonsoft.Json.git

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,2 @@
+packages/
+!packages/repositories.config

--- a/template/CordovaWP8AppProj.csproj
+++ b/template/CordovaWP8AppProj.csproj
@@ -204,6 +204,7 @@
     <None Include="cordova\run.bat" />
     <None Include="cordova\version.bat" />
     <Content Include="VERSION" />
+    <None Include="packages.config" />
     <None Include="Properties\AppManifest.xml">
       <SubType>Designer</SubType>
     </None>
@@ -227,7 +228,9 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-     <Compile Include="cordovalib\JSON\lib\Newtonsoft.Json\Src\Newtonsoft.Json\**\*.cs" /> 
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />

--- a/template/CordovaWP8AppProj.csproj
+++ b/template/CordovaWP8AppProj.csproj
@@ -226,6 +226,9 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup>
+     <Compile Include="cordovalib\JSON\lib\Newtonsoft.Json\Src\Newtonsoft.Json\**\*.cs" /> 
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/template/cordovalib/JSON/JsonHelper.cs
+++ b/template/cordovalib/JSON/JsonHelper.cs
@@ -12,20 +12,8 @@
 	limitations under the License.
 */
 
+using Newtonsoft.Json;
 using System;
-using System.Net;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Ink;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Windows.Shapes;
-using System.Runtime.Serialization.Json;
-using System.IO;
-using System.Collections.Generic;
-using System.Text;
 using System.Diagnostics;
 
 namespace WPCordovaClassLib.Cordova.JSON
@@ -42,26 +30,17 @@ namespace WPCordovaClassLib.Cordova.JSON
         /// <returns>JSON representation of the object. Returns 'null' string for null passed as argument</returns>
         public static string Serialize(object obj)
         {
-            if (obj == null)
-            {
-                return "null";
-            }
-
-            DataContractJsonSerializer ser = new DataContractJsonSerializer(obj.GetType());
-
-            MemoryStream ms = new MemoryStream();
-            ser.WriteObject(ms, obj);
-
-            ms.Position = 0;
-
             string json = String.Empty;
 
-            using (StreamReader sr = new StreamReader(ms))
+            try
             {
-                json = sr.ReadToEnd();
+                json = JsonConvert.SerializeObject(obj);
             }
-
-            ms.Close();
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                Debug.WriteLine("Failed to serialize " + obj);
+            }
 
             return json;
 
@@ -75,14 +54,10 @@ namespace WPCordovaClassLib.Cordova.JSON
         /// <returns>Deserialized object instance</returns>
         public static T Deserialize<T>(string json)
         {
-            DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
             object result = null;
             try
             {
-                using (MemoryStream mem = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-                {
-                    result = deserializer.ReadObject(mem);
-                }
+                result = JsonConvert.DeserializeObject<T>(json);
             }
             catch (Exception ex)
             {

--- a/template/packages.config
+++ b/template/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="wp80" />
+</packages>

--- a/template/packages/repositories.config
+++ b/template/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\packages.config" />
+</repositories>

--- a/testing/.nuget/packages.config
+++ b/testing/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Runners" version="2.6.3" />
+</packages>

--- a/testing/CordovaLib/CordovaLib.csproj
+++ b/testing/CordovaLib/CordovaLib.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CordovaLib</RootNamespace>
+    <AssemblyName>CordovaLib</AssemblyName>
+    <DefaultLanguage>es-ES</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\template\cordovalib\JSON\JsonHelper.cs">
+      <Link>CordovaLib\JSON\JsonHelper.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <TargetPlatform Include="WindowsPhoneApp, Version=8.1" />
+    <TargetPlatform Include="Windows, Version=8.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\template\cordovalib\JSON\lib\Newtonsoft.Json\Src\Newtonsoft.Json\Newtonsoft.Json.Portable40.csproj">
+      <Project>{959f7f85-c98b-4876-971a-9036224578e4}</Project>
+      <Name>Newtonsoft.Json.Portable40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/testing/CordovaLib/Properties/AssemblyInfo.cs
+++ b/testing/CordovaLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// La información general sobre un ensamblado se controla mediante el siguiente 
+// conjunto de atributos. Cambie estos atributos para modificar la información
+// asociada con un ensamblado.
+[assembly: AssemblyTitle("CordovaLib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CordovaLib")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("es")]
+
+// La información de versión de un ensamblado consta de los cuatro valores siguientes:
+//
+//      Versión principal
+//      Versión secundaria 
+//      Número de compilación
+//      Revisión
+//
+// Puede especificar todos los valores o establecer como predeterminados los números de compilación y de revisión 
+// mediante el carácter '*', como se muestra a continuación:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/testing/CordovaLib_Testing.sln
+++ b/testing/CordovaLib_Testing.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Express 2013 for Windows
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CordovaLib", "CordovaLib\CordovaLib.csproj", "{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CordovaLib_Testing", "CordovaLib_Testing\CordovaLib_Testing.csproj", "{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{64FBFFCF-D157-45C6-85B3-69220E01BB19}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Newtonsoft.Json.Portable40", "..\template\cordovalib\JSON\lib\Newtonsoft.Json\Src\Newtonsoft.Json\Newtonsoft.Json.Portable40.csproj", "{959F7F85-C98B-4876-971A-9036224578E4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12FD3A7C-F0D1-44A2-88E1-3E0FC7400DE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{959F7F85-C98B-4876-971A-9036224578E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{959F7F85-C98B-4876-971A-9036224578E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{959F7F85-C98B-4876-971A-9036224578E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{959F7F85-C98B-4876-971A-9036224578E4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/testing/CordovaLib_Testing/CordovaLib_Testing.csproj
+++ b/testing/CordovaLib_Testing/CordovaLib_Testing.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{362196A1-4FFD-4653-B2F0-C6F1867D3C9A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CordovaLib_Testing</RootNamespace>
+    <AssemblyName>CordovaLib_Testing</AssemblyName>
+    <DefaultLanguage>es-ES</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <ProjectReference Include="..\CordovaLib\CordovaLib.csproj">
+      <Project>{12fd3a7c-f0d1-44a2-88e1-3e0fc7400de7}</Project>
+      <Name>CordovaLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <TargetPlatform Include="WindowsPhoneApp, Version=8.1" />
+    <TargetPlatform Include="Windows, Version=8.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="JsonHelperTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/testing/CordovaLib_Testing/JsonHelperTest.cs
+++ b/testing/CordovaLib_Testing/JsonHelperTest.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using WPCordovaClassLib.Cordova.JSON;
+
+namespace CordovaLib_Testing
+{
+    [TestFixture]
+    public class JsonHelperTest
+    {
+        [Test]
+        public void SimpleJsonDeserializeTest()
+        {
+            string input = "[\"///CapturedImagesCache/WP_20141010_001.jpg\",\"http://foo.bar.net/foobar\",\"file\",\"WP_20141010_001.jpg\",\"image/jpg\",\"{}\",null,\"false\", \"1\",\"POST\",\"FileTransfer1982537557\"]";
+
+            string[] args = JsonHelper.Deserialize<string[]>(input);
+
+            Assert.AreEqual(11, args.Length);
+            Assert.AreEqual("///CapturedImagesCache/WP_20141010_001.jpg", args[0]);
+            Assert.AreEqual("http://foo.bar.net/foobar", args[1]);
+            Assert.AreEqual("file", args[2]);
+            Assert.AreEqual("WP_20141010_001.jpg", args[3]);
+            Assert.AreEqual("image/jpg", args[4]);
+            Assert.AreEqual("{}", args[5]);
+            Assert.IsNull(args[6]);
+            Assert.AreEqual("false", args[7]);
+            Assert.AreEqual("1", args[8]);
+            Assert.AreEqual("POST", args[9]);
+            Assert.AreEqual("FileTransfer1982537557", args[10]);
+        }
+
+        [Test]
+        public void SimpleJsonSerializeTest()
+        {
+            string input = "[\"///CapturedImagesCache/WP_20141010_001.jpg\",\"http://foo.bar.net/foobar\",\"file\",\"WP_20141010_001.jpg\",\"image/jpg\",\"{}\",null,\"false\",\"1\",\"POST\",\"FileTransfer1982537557\"]";
+
+            string[] args = { "///CapturedImagesCache/WP_20141010_001.jpg", "http://foo.bar.net/foobar", "file", "WP_20141010_001.jpg", "image/jpg", "{}", null, "false", "1", "POST", "FileTransfer1982537557" };
+
+            string compiled = JsonHelper.Serialize(args);
+
+            Assert.AreEqual(input, compiled);
+        }
+
+        [Test]
+        public void ComplexJsonDeserializeTest()
+        {
+            string complexHeader = "{\"x-wsse\":\"UsernameToken Username=\\\"foo@bar.net\\\", PasswordDigest=\\\"ZTQXXXXXXXXXXXXXXXXXXXXXXXXXXXX0NTJlMGE2M2I0NGJiYWM4NA==\\\", Nonce=\\\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXA==\\\", Created=\\\"2014-10-11T18:48:07.232Z\\\"\"}";
+
+            Dictionary<string, string> decompiled = JsonHelper.Deserialize<Dictionary<string, string>>(complexHeader);
+
+            Assert.IsNotNull(decompiled);
+            Assert.True(decompiled.ContainsKey("x-wsse"));
+        }
+
+        [Test]
+        public void ComplexJsonSerializeTest()
+        {
+            Dictionary<string, string> decompiled = new Dictionary<string, string>();
+            decompiled.Add("x-wsse", "UsernameToken Username=\"foo@bar.net\", PasswordDigest=\"ZTQXXXXXXXXXXXXXXXXXXXXXXXXXXXX0NTJlMGE2M2I0NGJiYWM4NA==\", Nonce=\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXA==\", Created=\"2014-10-11T18:48:07.232Z\"");
+
+            string compiled = JsonHelper.Serialize(decompiled);
+
+            Assert.AreEqual("{\"x-wsse\":\"UsernameToken Username=\\\"foo@bar.net\\\", PasswordDigest=\\\"ZTQXXXXXXXXXXXXXXXXXXXXXXXXXXXX0NTJlMGE2M2I0NGJiYWM4NA==\\\", Nonce=\\\"XXXXXXXXXXXXXXXXXXXXXXXXXXXXA==\\\", Created=\\\"2014-10-11T18:48:07.232Z\\\"\"}", compiled);
+        }
+    }
+}

--- a/testing/CordovaLib_Testing/Properties/AssemblyInfo.cs
+++ b/testing/CordovaLib_Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// La información general sobre un ensamblado se controla mediante el siguiente 
+// conjunto de atributos. Cambie estos atributos para modificar la información
+// asociada con un ensamblado.
+[assembly: AssemblyTitle("CordovaLib_Testing")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CordovaLib_Testing")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("es")]
+
+// La información de versión de un ensamblado consta de los cuatro valores siguientes:
+//
+//      Versión principal
+//      Versión secundaria 
+//      Número de compilación
+//      Revisión
+//
+// Puede especificar todos los valores o establecer como predeterminados los números de compilación y de revisión 
+// mediante el carácter '*', como se muestra a continuación:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/testing/CordovaLib_Testing/packages.config
+++ b/testing/CordovaLib_Testing/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="portable-win81+wpa81" />
+</packages>


### PR DESCRIPTION
When I tried to parse a WSSE security header with **JsonHelper**, I noticed that the **DataContractJsonSerializer** doesn't return the wanted output.

That is because, the WSSE patterns has extra commas and colons in the value string, like that:

```
UsernameToken Username="foo@bar.net", PasswordDigest="ZTQXXXXXXXXXXXXXXXXXXXXXXXXXXXX0NTJlMGE2M2I0NGJiYWM4NA==", Nonce="XXXXXXXXXXXXXXXXXXXXXXXXXXXXA==", Created="2014-10-11T18:48:07.232Z"
```

I recommend to delegate the serialization/deserialization of JSON in the library Newtonsoft.Json for performance and a better result.

