### PR TITLE
CB-7858 Fix onload="true"

### DIFF
--- a/template/cordovalib/ConfigHandler.cs
+++ b/template/cordovalib/ConfigHandler.cs
@@ -186,8 +186,7 @@ namespace WPCordovaClassLib.CordovaLib
         {
             get
             {
-                // TODO:
-                var res = from results in AllowedPlugins.TakeWhile(p => p.Value.isAutoLoad)
+                var res = from results in AllowedPlugins.Where(p => p.Value.isAutoLoad)
                           select results.Value.Name;
 
                 return res.ToArray<string>();


### PR DESCRIPTION
Replace `TakeWhile` with `Where` so that _AutoloadPlugins_ returns all plugins for which `onload="true"`.

Fixes https://issues.apache.org/jira/browse/CB-7858.
