### PR TITLE
Improved console logging

### DIFF
--- a/template/cordovalib/ConsoleHelper.cs
+++ b/template/cordovalib/ConsoleHelper.cs
@@ -50,14 +50,30 @@ namespace WPCordovaClassLib.CordovaLib
             {
             }
 
-            string script = @"(function(win) {
-        function exec(msg) { window.external.Notify('ConsoleLog/' + msg); }
+            string script = 
+    @"(function(win) {
+        function stringify() { 
+            // Convert arguments to strings and concat them with comma.
+            return Array.prototype.map.call( arguments, function argumentToString( argument ) { 
+                        // Return primitives as string.
+                        if( typeof argument === 'string' || typeof argument === 'number' ) {
+                            return argument;
+                        }
+                        if( typeof argument === 'function' ) {
+                            return argument.toString();
+                        }
+                        // Convert complex arguments to JSON.
+                        return JSON.stringify( argument );
+                    } )
+                        .join( ',' ); 
+        }
+        function exec() { window.external.Notify( 'ConsoleLog/' + stringify.apply( null, arguments ) ); }
         var cons = win.console = win.console || {};
         cons.log = exec;
         cons.debug = cons.debug || cons.log;
-        cons.info = cons.info   || function(msg) { exec('INFO:' + msg ); };     
-        cons.warn = cons.warn   || function(msg) { exec('WARN:' + msg ); };
-        cons.error = cons.error || function(msg) { exec('ERROR:' + msg ); };
+        cons.info = cons.info   || function() { exec( 'INFO:' + stringify.apply( null, arguments ) ); };
+        cons.warn = cons.warn   || function() { exec( 'WARN:' + stringify.apply( null, arguments ) ); };
+        cons.error = cons.error || function() { exec( 'ERROR:' + stringify.apply( null, arguments ) ); };
     })(window);";
 
             Browser.InvokeScript("eval", new string[] { script });

--- a/template/cordovalib/ConsoleHelper.cs
+++ b/template/cordovalib/ConsoleHelper.cs
@@ -63,7 +63,11 @@ namespace WPCordovaClassLib.CordovaLib
                             return argument.toString();
                         }
                         // Convert complex arguments to JSON.
-                        return JSON.stringify( argument );
+                        try {
+                            return JSON.stringify( argument );
+                        } catch( ignored ) {
+                            return argument.toString();
+                        }
                     } )
                         .join( ',' ); 
         }


### PR DESCRIPTION
Previously, when using console.log facilities, only the first argument was respected by ConsoleHelper, resulting in information not being logged when `console.log` was invoked with multiple arguments.
Additionally, arguments would be converted straight to strings, resulting in `[object Object]` or similar results in the log.

This change allows any number of arguments to be passed to the logging functions and it converts the inputs to a representation that is useful when debugging the application.

A call like `log( "a", 123, { foo: 'bar' }, function() { return 'baz'; } );`
Results in: `a,123,{"foo":"bar"},function () { return 'baz'; }`