### PR TITLE
CB-8139 WP8. Fix callback for plugins with native ui (capture, contactPicker, etc)

### DIFF
--- a/template/cordovalib/ConsoleHelper.cs
+++ b/template/cordovalib/ConsoleHelper.cs
@@ -38,13 +38,6 @@ namespace WPCordovaClassLib.CordovaLib
             {
             }
 
-            if (!hasListener)
-            {
-                PhoneApplicationService.Current.Closing += OnServiceClosing;
-                hasListener = true;
-            }
-
-
             string script = @"(function(win) {
         function exec(msg) { window.external.Notify('ConsoleLog/' + msg); }
         var cons = win.console = win.console || {};
@@ -71,15 +64,6 @@ namespace WPCordovaClassLib.CordovaLib
             }
         }
 
-        public void DetachHandler()
-        {
-            if (hasListener)
-            {
-                PhoneApplicationService.Current.Closing -= OnServiceClosing;
-                hasListener = false;
-            }
-        }
-
         public bool HandleCommand(string commandStr)
         {
             string output = commandStr.Substring("ConsoleLog/".Length);
@@ -94,6 +78,16 @@ namespace WPCordovaClassLib.CordovaLib
                 file.Close();
             }
             return true;
+        }
+
+        public void AttachNativeHandlers()
+        {
+            PhoneApplicationService.Current.Closing += OnServiceClosing;
+        }
+
+        public void DetachNativeHandlers()
+        {
+            PhoneApplicationService.Current.Closing -= OnServiceClosing;
         }
 
     }

--- a/template/cordovalib/CordovaView.xaml.cs
+++ b/template/cordovalib/CordovaView.xaml.cs
@@ -136,22 +136,6 @@ namespace WPCordovaClassLib
                 return;
             }
 
-
-            StartupMode mode = PhoneApplicationService.Current.StartupMode;
-
-            if (mode == StartupMode.Launch)
-            {
-                PhoneApplicationService service = PhoneApplicationService.Current;
-                service.Activated += new EventHandler<Microsoft.Phone.Shell.ActivatedEventArgs>(AppActivated);
-                service.Launching += new EventHandler<LaunchingEventArgs>(AppLaunching);
-                service.Deactivated += new EventHandler<DeactivatedEventArgs>(AppDeactivated);
-                service.Closing += new EventHandler<ClosingEventArgs>(AppClosing);
-            }
-            else
-            {
-
-            }
-
             // initializes native execution logic
             configHandler = new ConfigHandler();
             configHandler.LoadAppPackageConfig();
@@ -270,6 +254,18 @@ namespace WPCordovaClassLib
 
         void CordovaBrowser_Loaded(object sender, RoutedEventArgs e)
         {
+          
+            PhoneApplicationService service = PhoneApplicationService.Current;
+            service.Activated += new EventHandler<Microsoft.Phone.Shell.ActivatedEventArgs>(AppActivated);
+            service.Launching += new EventHandler<LaunchingEventArgs>(AppLaunching);
+            service.Deactivated += new EventHandler<DeactivatedEventArgs>(AppDeactivated);
+            service.Closing += new EventHandler<ClosingEventArgs>(AppClosing);
+
+            foreach (IBrowserDecorator iBD in browserDecorators.Values)
+            {
+                iBD.AttachNativeHandlers();
+            }
+
 
             this.bmHelper.ScrollDisabled = this.DisableBouncyScrolling;
 
@@ -319,6 +315,20 @@ namespace WPCordovaClassLib
             catch (Exception ex)
             {
                 Debug.WriteLine("ERROR: Exception in CordovaBrowser_Loaded :: {0}", ex.Message);
+            }
+        }
+
+        private void CordovaBrowser_Unloaded(object sender, RoutedEventArgs e)
+        {
+            PhoneApplicationService service = PhoneApplicationService.Current;
+            service.Activated -= new EventHandler<Microsoft.Phone.Shell.ActivatedEventArgs>(AppActivated);
+            service.Launching -= new EventHandler<LaunchingEventArgs>(AppLaunching);
+            service.Deactivated -= new EventHandler<DeactivatedEventArgs>(AppDeactivated);
+            service.Closing -= new EventHandler<ClosingEventArgs>(AppClosing);
+
+            foreach (IBrowserDecorator iBD in browserDecorators.Values)
+            {
+                iBD.DetachNativeHandlers();
             }
         }
 
@@ -524,21 +534,6 @@ namespace WPCordovaClassLib
             }
         }
 
-        private void CordovaBrowser_Unloaded(object sender, RoutedEventArgs e)
-        {
-            IBrowserDecorator console;
-            if (browserDecorators.TryGetValue("ConsoleLog", out console))
-            {
-                ((ConsoleHelper)console).DetachHandler();
-            }
-
-            PhoneApplicationService service = PhoneApplicationService.Current;
-            service.Activated -= new EventHandler<Microsoft.Phone.Shell.ActivatedEventArgs>(AppActivated);
-            service.Launching -= new EventHandler<LaunchingEventArgs>(AppLaunching);
-            service.Deactivated -= new EventHandler<DeactivatedEventArgs>(AppDeactivated);
-            service.Closing -= new EventHandler<ClosingEventArgs>(AppClosing);
-        }
-
         private void CordovaBrowser_NavigationFailed(object sender, System.Windows.Navigation.NavigationFailedEventArgs e)
         {
             Debug.WriteLine("CordovaBrowser_NavigationFailed :: " + e.Uri.ToString());
@@ -546,10 +541,10 @@ namespace WPCordovaClassLib
 
         private void CordovaBrowser_Navigated(object sender, System.Windows.Navigation.NavigationEventArgs e)
         {
-           foreach(IBrowserDecorator iBD in browserDecorators.Values)
-           {
-               iBD.InjectScript();
-           }
+            foreach (IBrowserDecorator iBD in browserDecorators.Values)
+            {
+                iBD.InjectScript();
+            }
         }
 
         /// <summary>
@@ -575,6 +570,12 @@ namespace WPCordovaClassLib
                               (byte)((argb & 0xff00) >> 8),
                               (byte)(argb & 0xff));
             return clr;
+        }
+
+        ~CordovaView()
+        {
+            // This trace is useful when validating that CordovaView is correctly garbage collected
+            // Debug.WriteLine("CordovaView is destroyed");
         }
     }
 }

--- a/template/cordovalib/IBrowserDecorator.cs
+++ b/template/cordovalib/IBrowserDecorator.cs
@@ -26,5 +26,7 @@ namespace WPCordovaClassLib.CordovaLib
         WebBrowser Browser { get; set; }
         void InjectScript();
         bool HandleCommand(string cmd);
+        void AttachNativeHandlers();
+        void DetachNativeHandlers();
     }
 }

--- a/template/cordovalib/NativeExecution.cs
+++ b/template/cordovalib/NativeExecution.cs
@@ -52,21 +52,6 @@ namespace WPCordovaClassLib.Cordova
 
             this.webBrowser = browser;
             this.commands = new List<BaseCommand>();
-            webBrowser.Unloaded += webBrowser_Unloaded;
-        }
-
-        /// <summary>
-        /// Detaches event handlers to prevent memory leak on page navigation
-        /// </summary>
-        void webBrowser_Unloaded(object sender, RoutedEventArgs e)
-        {
-            for (int i = commands.Count - 1; i >= 0; i--)
-            {
-                if (commands[i] != null)
-                {
-                    commands[i].DetachHandlers();
-                }
-            }
         }
 
         /// <summary>
@@ -115,6 +100,12 @@ namespace WPCordovaClassLib.Cordova
                     return;
                 }
 
+                // TODO: consider removing custom script functionality at all since we already marked it as absolute (see BaseCommand)
+                EventHandler<ScriptCallback> OnCustomScriptHandler = delegate(object o, ScriptCallback script)
+                {
+                    this.InvokeScriptCallback(script);
+                };
+
                 EventHandler<PluginResult> OnCommandResultHandler = delegate(object o, PluginResult res)
                 {
                     if (res.CallbackId == null || res.CallbackId == commandCallParams.CallbackId)
@@ -123,17 +114,13 @@ namespace WPCordovaClassLib.Cordova
                         if (!res.KeepCallback)
                         {
                             bc.RemoveResultHandler(commandCallParams.CallbackId);
+                            bc.OnCustomScript -= OnCustomScriptHandler;
                         }
                     }
                 };
 
                 //bc.OnCommandResult += OnCommandResultHandler;
                 bc.AddResultHandler(commandCallParams.CallbackId, OnCommandResultHandler);
-
-                EventHandler<ScriptCallback> OnCustomScriptHandler = delegate(object o, ScriptCallback script)
-                {
-                    this.InvokeScriptCallback(script);
-                };
 
                 bc.OnCustomScript += OnCustomScriptHandler;
 

--- a/template/cordovalib/OrientationHelper.cs
+++ b/template/cordovalib/OrientationHelper.cs
@@ -125,6 +125,16 @@ namespace WPCordovaClassLib.Cordova
             // No commands are currently accepted.
             return true;
         }
+
+        public void AttachNativeHandlers()
+        {
+            // nothing to do
+        }
+
+        public void DetachNativeHandlers()
+        {
+            // nothing to do
+        }
     }
 
 

--- a/template/cordovalib/XHRHelper.cs
+++ b/template/cordovalib/XHRHelper.cs
@@ -342,5 +342,15 @@ namespace WPCordovaClassLib.CordovaLib
 
             return false;
         }
+
+        public void AttachNativeHandlers()
+        {
+            // nothing to do
+        }
+
+        public void DetachNativeHandlers()
+        {
+            // nothing to do
+        }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-8139

Unload event could not be used to detect when CordovaView is not used anymore. For example, this event is triggered when we execute command that shows some native elements on new page and then we return back. In this case Unloaded event is called but, but control state is preserved and we should continue to use that Cordova view instance. Same happens when app is deactivated and then activated again (switch between apps)

This commit changes the following:
1. Allows command instances to be garbage collected => fixes corresponding memory leak so that NativeExecution is no more required to call DetachHandlers for each command. This fixes  CB-8139.
2. Use Loaded and Unloaded events to add/remove handlers for native events; this makes it possible for GC to destroy CordovaView when it is not required anymore
