### PR TITLE
Use WP8 thread pool for each command, instead of starting new thread

### DIFF
--- a/template/cordovalib/NativeExecution.cs
+++ b/template/cordovalib/NativeExecution.cs
@@ -124,7 +124,7 @@ namespace WPCordovaClassLib.Cordova
 
                 bc.OnCustomScript += OnCustomScriptHandler;
 
-                ThreadStart methodInvokation = () =>
+                Windows.System.Threading.ThreadPool.RunAsync((workItem) =>
                 {
                     try
                     {
@@ -141,9 +141,7 @@ namespace WPCordovaClassLib.Cordova
                         this.OnCommandResult(commandCallParams.CallbackId, new PluginResult(PluginResult.Status.INVALID_ACTION));
                         return;
                     }
-                };
-
-                new Thread(methodInvokation).Start();
+                });
 
             }
             catch (Exception ex)


### PR DESCRIPTION
As reported in [CB-7443](https://issues.apache.org/jira/browse/CB-7443), ref: https://msdn.microsoft.com/en-us/library/windows/apps/jj248677.aspx

The [sqlite plugin](https://github.com/brodysoft/Cordova-SQLitePlugin) test suite is running faster with no problems on the simulator. Needs review and perhaps some more testing.

I am more than happy to sign the Individual CLA, if necessary.