### PR TITLE
CB-8516 Support DefaultLanguage selection for WP8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
         "nopt": "~3",
         "shelljs": "~0.3",
         "node-uuid": "~1.4",
-        "q": "~1"
+        "q": "~1",
+        "elementtree": "~0.1.5"
     },
     "bundledDependencies": [
         "nopt",
         "shelljs",
         "node-uuid",
-        "q"
+        "q",
+        "elementtree"
     ],
     "devDependencies": {
         "jasmine-node": "~1",


### PR DESCRIPTION
Cordova should set the appropriate project file attributes for WP 8.0 using the W3C widget spec "defaultlocale" attribute.

Related JIRA: https://issues.apache.org/jira/browse/CB-8516