### PR TITLE
Newtonsoft no conflict

### DIFF
--- a/template/cordovalib/JSON/JsonHelper.cs
+++ b/template/cordovalib/JSON/JsonHelper.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization.Json;
 using System.IO;
 using System.Text;
 using System.Diagnostics;
+using Newtonsoft.Json;
 
 namespace WPCordovaClassLib.Cordova.JSON
 {
@@ -30,30 +31,37 @@ namespace WPCordovaClassLib.Cordova.JSON
         /// </summary>
         /// <param name="obj">object to serialize</param>
         /// <returns>JSON representation of the object. Returns 'null' string for null passed as argument</returns>
-        public static string Serialize(object obj)
+        public static string Serialize(object obj, bool bUseJsonDotNet = false)
         {
-            if (obj == null)
+            if (bUseJsonDotNet)
+            {
+                return JsonConvert.SerializeObject(obj);
+            }
+            else if (obj == null)
             {
                 return "null";
             }
-
-            DataContractJsonSerializer ser = new DataContractJsonSerializer(obj.GetType());
-
-            MemoryStream ms = new MemoryStream();
-            ser.WriteObject(ms, obj);
-
-            ms.Position = 0;
-
-            string json = String.Empty;
-
-            using (StreamReader sr = new StreamReader(ms))
+            else
             {
-                json = sr.ReadToEnd();
+
+                DataContractJsonSerializer ser = new DataContractJsonSerializer(obj.GetType());
+
+                MemoryStream ms = new MemoryStream();
+                ser.WriteObject(ms, obj);
+
+                ms.Position = 0;
+
+                string json = String.Empty;
+
+                using (StreamReader sr = new StreamReader(ms))
+                {
+                    json = sr.ReadToEnd();
+                }
+
+                ms.Close();
+
+                return json;
             }
-
-            ms.Close();
-
-            return json;
 
         }
 
@@ -63,24 +71,32 @@ namespace WPCordovaClassLib.Cordova.JSON
         /// <typeparam name="T">type of the object</typeparam>
         /// <param name="json">json string representation of the object</param>
         /// <returns>Deserialized object instance</returns>
-        public static T Deserialize<T>(string json)
+        public static T Deserialize<T>(string json, bool bUseJsonDotNet = false)
         {
-            DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
-            object result = null;
-            try
-            {
-                using (MemoryStream mem = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-                {
-                    result = deserializer.ReadObject(mem);
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                Debug.WriteLine("Failed to deserialize " + typeof(T) + " with JSON value :: " + json);
-            }
 
-            return (T)result;
+            if (bUseJsonDotNet)
+            {
+                return JsonConvert.DeserializeObject<T>(json);
+            }
+            else
+            {
+                DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
+                object result = null;
+                try
+                {
+                    using (MemoryStream mem = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+                    {
+                        result = deserializer.ReadObject(mem);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex.Message);
+                    Debug.WriteLine("Failed to deserialize " + typeof(T) + " with JSON value :: " + json);
+                }
+
+                return (T)result;
+            }
 
         }
     }


### PR DESCRIPTION
The Newtonsoft.json dll still exists, but it's use is now optional.
This is the result of discovery that some plugins have become dependent on the way the DataContractJsonSerializer works.