### PR TITLE
Remove `ecosystem:cordova` keyword from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
         "wp8",
         "windowsphone",
         "cordova",
-        "apache",
-        "ecosystem:cordova"
+        "apache"
     ],
     "dependencies": {
         "nopt": "~3",


### PR DESCRIPTION
This needs to be removed as it shows up in Cordova plugin search where it's not relevant.