### PR TITLE
Get rid of Math.random() when making a request ID

### DIFF
--- a/template/cordovalib/XHRHelper.cs
+++ b/template/cordovalib/XHRHelper.cs
@@ -77,6 +77,7 @@ namespace WPCordovaClassLib.CordovaLib
         XHRShim.HEADERS_RECEIVED = 2;
         XHRShim.LOADING = 3;
         XHRShim.DONE = 4;
+        XHRShim.incrementedCounter = 0;
         XHRShim.prototype = {
             isAsync: false,
             onreadystatechange: null,
@@ -263,7 +264,7 @@ namespace WPCordovaClassLib.CordovaLib
                     }
 
                     // Generate unique request ID
-                    var reqId = new Date().getTime().toString() + Math.random();
+                    var reqId = new Date().getTime().toString() + XHRShim.incrementedCounter++;
 
                     var funk = function () {
                         __XHRShimAliases[reqId] = alias;


### PR DESCRIPTION
Math.random() takes several seconds to work (at least on my Lumia 820)! That's why, when using AngularJS routing I experienced huge delays when loading partial views. This little change fixed that.

Can't file an issue in JIRA, because it fails to load in my browser. So just proposing this pull request...