### PR TITLE
Move AutoLoadCommand execution in FrameworkElement.Loaded event

### DIFF
--- a/template/cordovalib/CordovaView.xaml.cs
+++ b/template/cordovalib/CordovaView.xaml.cs
@@ -308,6 +308,12 @@ namespace WPCordovaClassLib
                     }
                 }
 
+                string[] autoloadPlugs = this.configHandler.AutoloadPlugins;
+                foreach (string plugName in autoloadPlugs)
+                {
+                    nativeExecution.AutoLoadCommand(plugName);
+                }
+
                 CordovaBrowser.Navigate(StartPageUri);
                 IsBrowserInitialized = true;
                 AttachHardwareButtonHandlers();
@@ -355,6 +361,10 @@ namespace WPCordovaClassLib
 
         void page_BackKeyPress(object sender, CancelEventArgs e)
         {
+            if (e.Cancel)
+            {
+                return;
+            }
 
             if (OverrideBackButton)
             {
@@ -411,12 +421,6 @@ namespace WPCordovaClassLib
                 }
             }
             Debug.WriteLine("Apache Cordova native platform version " + version + " is starting");
-
-            string[] autoloadPlugs = this.configHandler.AutoloadPlugins;
-            foreach (string plugName in autoloadPlugs)
-            {
-                nativeExecution.AutoLoadCommand(plugName);
-            }
 
             // send js code to fire ready event
             string nativeReady = "(function(){ cordova.require('cordova/channel').onNativeReady.fire()})();";


### PR DESCRIPTION
- Add AutoLoadCommand execution in FrameworkElement.Loaded event and remove it from CordovaBrowser_LoadCompleted
  - This change is done, because the auto-load plugins should be initialized once and before the CordovaBrowser page load complete event (as it works in iOS and Android). Via this change the OnInit method will be invoked only once and for example the splashscreen plugin will start immediately instead of waiting the page to load.
- Respect the CancelEventArgs.Cancel Property in page_BackKeyPress
