### PR TITLE
Module 'q' is lowercase

### DIFF
--- a/bin/lib/check_reqs.js
+++ b/bin/lib/check_reqs.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-var Q = require('Q');
+var Q = require('q');
 
 var MSBuildTools;
 try {


### PR DESCRIPTION
This is giving me errors trying to add wp8 platform on a Linux system. I found similar erros [here](https://github.com/driftyco/ionic-cli/issues/484) and [here](https://github.com/apache/cordova-ios/pull/132#issue-59368079).  

Error output:
```
❯ ionic platform add wp8
Updated the hooks directory to have execute permissions
WARNING: Applications for platform wp8 can not be built on this OS - linux.
Adding wp8 project...
module.js:339
    throw err;
    ^

Error: Cannot find module 'Q'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/home/pedroxs/.cordova/lib/npm_cache/cordova-wp8/3.8.1/package/bin/lib/create.js:20:13)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
Error: /home/pedroxs/.cordova/lib/npm_cache/cordova-wp8/3.8.1/package/bin/create: Command failed with exit code 1
    at ChildProcess.whenDone (/home/pedroxs/.nvm/versions/node/v4.2.1/lib/node_modules/cordova/node_modules/cordova-lib/src/cordova/superspawn.js:139:23)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:818:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
```